### PR TITLE
Updates the deprecated and removed document ready event to .ready()

### DIFF
--- a/app/assets/javascripts/activeadmin_addons/addons/interactive_select_tag.js
+++ b/app/assets/javascripts/activeadmin_addons/addons/interactive_select_tag.js
@@ -1,4 +1,4 @@
-$(document).on('ready turbolinks:load', function() {
+var initializer = function() {
   configureInteractiveSelect(document);
 
   $(document).on('has_many_add:after', function(event, container) {
@@ -88,4 +88,7 @@ $(document).on('ready turbolinks:load', function() {
       });
     }
   });
-});
+};
+
+$(initializer);
+$(document).on('turbolinks:load', initializer);

--- a/app/assets/javascripts/activeadmin_addons/addons/toggle_bool.js
+++ b/app/assets/javascripts/activeadmin_addons/addons/toggle_bool.js
@@ -1,4 +1,4 @@
-$(document).on('ready turbolinks:load', function() {
+var initializer = function() {
   $('.toggle-bool-switch').click(function(e) {
     var boolSwitch = $(e.target);
     var model = boolSwitch.data('model');
@@ -33,4 +33,7 @@ $(document).on('ready turbolinks:load', function() {
       type: 'PATCH',
     });
   });
-});
+};
+
+$(initializer);
+$(document).on('turbolinks:load', initializer);

--- a/app/assets/javascripts/activeadmin_addons/config.js
+++ b/app/assets/javascripts/activeadmin_addons/config.js
@@ -1,7 +1,10 @@
-$(document).on('ready turbolinks:load', function() {
+var initializer = function() {
   ActiveadminAddons = {
     config: {
       defaultSelect: $('body').data('default-select'),
     },
   };
-});
+};
+
+$(initializer);
+$(document).on('turbolinks:load', initializer);

--- a/app/assets/javascripts/activeadmin_addons/inputs/color-picker.js
+++ b/app/assets/javascripts/activeadmin_addons/inputs/color-picker.js
@@ -1,4 +1,4 @@
-$(document).on('ready turbolinks:load', function() {
+var initializer = function() {
   setupColorPicker();
 
   $(document).on('has_many_add:after', setupColorPicker);
@@ -10,4 +10,7 @@ $(document).on('ready turbolinks:load', function() {
       });
     });
   }
-});
+};
+
+$(initializer);
+$(document).on('turbolinks:load', initializer);

--- a/app/assets/javascripts/activeadmin_addons/inputs/date-time-picker.js
+++ b/app/assets/javascripts/activeadmin_addons/inputs/date-time-picker.js
@@ -1,4 +1,4 @@
-$(document).on('ready turbolinks:load', function() {
+var initializer = function() {
   setupDateTimePicker(document);
 
   $(document).on('has_many_add:after', '.has_many_container', function(event, fieldset) {
@@ -22,4 +22,7 @@ $(document).on('ready turbolinks:load', function() {
       return $(entry).datetimepicker(mixedOptions);
     });
   }
-});
+};
+
+$(initializer);
+$(document).on('turbolinks:load', initializer);

--- a/app/assets/javascripts/activeadmin_addons/inputs/nested-select.js
+++ b/app/assets/javascripts/activeadmin_addons/inputs/nested-select.js
@@ -54,7 +54,7 @@ $.fn.select2.amd.define('select2/data/nestedCustomAdapter', ['select2/data/array
   return CustomData;
 });
 
-$(document).on('ready turbolinks:load', function() {
+var initializer = function() {
   configureSelect2(document);
 
   $(document).on('has_many_add:after', function(event, container) {
@@ -158,4 +158,7 @@ $(document).on('ready turbolinks:load', function() {
       }
     });
   }
-});
+};
+
+$(initializer);
+$(document).on('turbolinks:load', initializer);

--- a/app/assets/javascripts/activeadmin_addons/inputs/search-select.js
+++ b/app/assets/javascripts/activeadmin_addons/inputs/search-select.js
@@ -1,4 +1,4 @@
-$(document).on('ready turbolinks:load', function() {
+var initializer = function() {
   setupSearchSelect(document);
 
   $(document).on('has_many_add:after', function(event, container) {
@@ -70,4 +70,7 @@ $(document).on('ready turbolinks:load', function() {
       $(el).select2(selectOptions);
     });
   }
-});
+};
+
+$(initializer);
+$(document).on('turbolinks:load', initializer);

--- a/app/assets/javascripts/activeadmin_addons/inputs/select2.js
+++ b/app/assets/javascripts/activeadmin_addons/inputs/select2.js
@@ -1,4 +1,4 @@
-$(document).on('ready turbolinks:load', function() {
+var initializer = function() {
   configureSelect2(document);
 
   $(document).on('has_many_add:after', function(event, container) {
@@ -46,4 +46,7 @@ $(document).on('ready turbolinks:load', function() {
       });
     }
   }
-});
+};
+
+$(initializer);
+$(document).on('turbolinks:load', initializer);

--- a/app/assets/javascripts/activeadmin_addons/inputs/selected-list.js
+++ b/app/assets/javascripts/activeadmin_addons/inputs/selected-list.js
@@ -1,4 +1,4 @@
-$(document).on('ready turbolinks:load', function() {
+var initializer = function() {
   setupSelectedList(document);
 
   $(document).on('has_many_add:after', function(event, container) {
@@ -101,4 +101,7 @@ $(document).on('ready turbolinks:load', function() {
       }
     });
   }
-});
+};
+
+$(initializer);
+$(document).on('turbolinks:load', initializer);

--- a/app/assets/javascripts/activeadmin_addons/inputs/tags.js
+++ b/app/assets/javascripts/activeadmin_addons/inputs/tags.js
@@ -1,4 +1,4 @@
-$(document).on('ready turbolinks:load', function() {
+var initializer = function() {
   setupTags(document);
 
   $(document).on('has_many_add:after', function(event, container) {
@@ -70,4 +70,7 @@ $(document).on('ready turbolinks:load', function() {
       }
     });
   }
-});
+};
+
+$(initializer);
+$(document).on('turbolinks:load', initializer);


### PR DESCRIPTION
The `ready` event on the document was removed in jQuery 3.0 (which is why the specs are failing for https://github.com/platanus/activeadmin_addons/pull/208).
> There is also $(document).on( "ready", handler ), deprecated as of jQuery 1.8 and removed in jQuery 3.0. 
http://api.jquery.com/ready/

This updates the code to use the suggested syntax for `.ready()`